### PR TITLE
Adds Audrey the RSS parser

### DIFF
--- a/lib/audrey/audrey.ex
+++ b/lib/audrey/audrey.ex
@@ -1,0 +1,14 @@
+defmodule Audrey do
+  def parse(xml) do
+    {:ok, Audrey.Feed.parse(xml)}
+  catch
+    :exit, _ -> {:error, "expected element start tag"}
+  end
+
+  def parse!(xml) do
+    case parse(xml) do
+      {:ok, feed} -> feed
+      {:error, error} -> raise error
+    end
+  end
+end

--- a/lib/audrey/lib/feed.ex
+++ b/lib/audrey/lib/feed.ex
@@ -1,0 +1,13 @@
+defmodule Audrey.Feed do
+  import SweetXml
+
+  defstruct [:channel]
+
+  def parse(xml) do
+    %Audrey.Feed{channel: parse_channel(xml)}
+  end
+
+  defp parse_channel(xml) do
+    xml |> xpath(~x"//channel") |> Audrey.RSS.Channel.parse
+  end
+end

--- a/lib/audrey/lib/rss/channel.ex
+++ b/lib/audrey/lib/rss/channel.ex
@@ -1,0 +1,31 @@
+defmodule Audrey.RSS.Channel do
+  import SweetXml
+  import Audrey.Util, only: [format_value: 1]
+
+  defstruct [:title, :link, :description, items: []]
+
+  def parse(xml) do
+    %Audrey.RSS.Channel{
+      title: parse_title(xml),
+      link: parse_link(xml),
+      description: parse_description(xml),
+      items: parse_items(xml)
+    }
+  end
+
+  defp parse_title(xml) do
+    xml |> xpath(~x"./title/text()"s)
+  end
+
+  defp parse_link(xml) do
+    xml |> xpath(~x"./link/text()"s) |> format_value
+  end
+
+  defp parse_description(xml) do
+    xml |> xpath(~x"./description/text()"s) |> format_value
+  end
+
+  defp parse_items(xml) do
+    xml |> xpath(~x"./item"l) |> Enum.map(&Audrey.RSS.Item.parse(&1))
+  end
+end

--- a/lib/audrey/lib/rss/item.ex
+++ b/lib/audrey/lib/rss/item.ex
@@ -1,0 +1,31 @@
+defmodule Audrey.RSS.Item do
+  import SweetXml
+  import Audrey.Util, only: [format_value: 1]
+
+  defstruct [:title, :link, :description, :pub_date]
+
+  def parse(xml) do
+    %Audrey.RSS.Item{
+      title: parse_title(xml),
+      link: parse_link(xml),
+      description: parse_description(xml),
+      pub_date: parse_pub_date(xml)
+    }
+  end
+
+  defp parse_title(xml) do
+    xml |> xpath(~x"./title/text()"s) |> format_value
+  end
+
+  defp parse_link(xml) do
+    xml |> xpath(~x"./link/text()"s) |> format_value
+  end
+
+  defp parse_description(xml) do
+    xml |> xpath(~x"./description/text()"s) |> format_value
+  end
+
+  defp parse_pub_date(xml) do
+    xml |> xpath(~x"./pubDate/text()"s) |> format_value
+  end
+end

--- a/lib/audrey/lib/util.ex
+++ b/lib/audrey/lib/util.ex
@@ -1,0 +1,8 @@
+defmodule Audrey.Util do
+  def format_value(value) do
+    value |> String.strip |> value_or_nil
+  end
+
+  def value_or_nil(""), do: nil
+  def value_or_nil(value), do: value
+end

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Opencast.Mixfile do
      {:cowboy, "~> 1.0"},
      {:ja_serializer, github: "AgilionApps/ja_serializer"},
      {:ex_machina, "~> 0.5"},
+     {:sweet_xml, "~> 0.5.0"},
      {:excoveralls, "~> 0.4", only: :test}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,4 +21,5 @@
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.10.0"},
   "ranch": {:hex, :ranch, "1.2.0"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+  "sweet_xml": {:hex, :sweet_xml, "0.5.1"}}

--- a/test/audrey/audrey/rss/channel_test.exs
+++ b/test/audrey/audrey/rss/channel_test.exs
@@ -1,0 +1,40 @@
+defmodule Audrey.RSS.ChannelTest do
+  use ExUnit.Case, async: true
+
+  import Audrey.RSS.Channel
+
+  def channel_xml_basic do
+    """
+    <channel>
+      <title>JavaScript Fatigue</title>
+      <link>http://jsfatigue.com/</link>
+      <description>Too many tools. Too little time.</description>
+      <item><title>Ember</title></item>
+      <item><title>Angular</title></item>
+      <item><title>React</title></item>
+    </channel>
+    """
+  end
+
+  test "parses the title" do
+    channel = channel_xml_basic |> parse
+    assert channel.title == "JavaScript Fatigue"
+  end
+
+  test "parses the link" do
+    channel = channel_xml_basic |> parse
+    assert channel.link == "http://jsfatigue.com/"
+  end
+
+  test "parses the description" do
+    channel = channel_xml_basic |> parse
+    assert channel.description == "Too many tools. Too little time."
+  end
+
+  test "parses items" do
+    channel = channel_xml_basic |> parse
+    item_titles = Enum.map(channel.items, &Map.get(&1, :title))
+
+    assert item_titles == ["Ember", "Angular", "React"]
+  end
+end

--- a/test/audrey/audrey/rss/item_test.exs
+++ b/test/audrey/audrey/rss/item_test.exs
@@ -1,0 +1,36 @@
+defmodule Audrey.RSS.ItemTest do
+  use ExUnit.Case, async: true
+
+  import Audrey.RSS.Item
+
+  def item_xml_basic do
+    """
+    <item>
+      <title>Star City</title>
+      <link>http://liftoff.msfc.nasa.gov/news/news-starcity.asp</link>
+      <description>How do Americans even?</description>
+      <pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>
+    </item>
+    """
+  end
+
+  test "parses the title" do
+    item = item_xml_basic |> parse
+    assert item.title == "Star City"
+  end
+
+  test "parses the link" do
+    item = item_xml_basic |> parse
+    assert item.link == "http://liftoff.msfc.nasa.gov/news/news-starcity.asp"
+  end
+
+  test "parses the description" do
+    item = item_xml_basic |> parse
+    assert item.description == "How do Americans even?"
+  end
+
+  test "parses the pubDate" do
+    item = item_xml_basic |> parse
+    assert item.pub_date == "Tue, 03 Jun 2003 09:39:21 GMT"
+  end
+end

--- a/test/audrey/audrey_test.exs
+++ b/test/audrey/audrey_test.exs
@@ -1,0 +1,20 @@
+defmodule AudreyTest do
+  use ExUnit.Case, async: true
+
+  import Audrey
+
+  test "parse!/1: does not blow up when parsing an RSS 2.0 compliant XML" do
+    xml = File.read!("test/audrey/fixtures/rss2.xml")
+    assert parse!(xml)
+  end
+
+  test "parse!/1: raises an error when XML is invalid" do
+    xml = "not valid"
+    assert_raise RuntimeError, fn -> parse!(xml) end
+  end
+
+  test "has a channel" do
+    {:ok, feed} = File.read!("test/audrey/fixtures/rss2.xml") |> parse
+    assert feed.channel
+  end
+end

--- a/test/audrey/fixtures/rss2.xml
+++ b/test/audrey/fixtures/rss2.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<rss version="2.0">
+   <channel>
+      <title>Liftoff News</title>
+      <link>http://liftoff.msfc.nasa.gov/</link>
+      <description>Liftoff to Space Exploration.</description>
+      <language>en-us</language>
+      <pubDate>Tue, 10 Jun 2003 04:00:00 GMT</pubDate>
+      <lastBuildDate>Tue, 10 Jun 2003 09:41:01 GMT</lastBuildDate>
+      <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+      <generator>Weblog Editor 2.0</generator>
+      <managingEditor>editor@example.com</managingEditor>
+      <webMaster>webmaster@example.com</webMaster>
+      <item>
+         <title>Star City</title>
+         <link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>
+         <description>How do Americans Even?</description>
+         <pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>
+         <guid>http://liftoff.msfc.nasa.gov/2003/06/03.html#item573</guid>
+      </item>
+      <item>
+         <description>Sky watchers in Europe, Asia, and parts of Alaska and Canada will experience a &lt;a href="http://science.nasa.gov/headlines/y2003/30may_solareclipse.htm"&gt;partial eclipse of the Sun&lt;/a&gt; on Saturday, May 31st.</description>
+         <pubDate>Fri, 30 May 2003 11:06:42 GMT</pubDate>
+         <guid>http://liftoff.msfc.nasa.gov/2003/05/30.html#item572</guid>
+      </item>
+      <item>
+         <title>The Engine That Does More</title>
+         <link>http://liftoff.msfc.nasa.gov/news/2003/news-VASIMR.asp</link>
+         <description>Before man travels to Mars, NASA hopes to design new engines that will let us fly through the Solar System more quickly.  The proposed VASIMR engine would do that.</description>
+         <pubDate>Tue, 27 May 2003 08:37:32 GMT</pubDate>
+         <guid>http://liftoff.msfc.nasa.gov/2003/05/27.html#item571</guid>
+      </item>
+      <item>
+         <title>Astronauts' Dirty Laundry</title>
+         <link>http://liftoff.msfc.nasa.gov/news/2003/news-laundry.asp</link>
+         <description>Compared to earlier spacecraft, the International Space Station has many luxuries, but laundry facilities are not one of them.  Instead, astronauts have other options.</description>
+         <pubDate>Tue, 20 May 2003 08:56:02 GMT</pubDate>
+         <guid>http://liftoff.msfc.nasa.gov/2003/05/20.html#item570</guid>
+      </item>
+   </channel>
+</rss>


### PR DESCRIPTION
Adds the beginning of a basic RSS parser to be used when parsing RSS
feeds that will be converted into Podcasts.

Currently supports parsing basic RSS feeds including:

- Basic channel parsing with support for title, description, link
- Basic item parsing with support for title, description, link, pubDate