### PR TITLE
Add <image> parsing for feed channels

### DIFF
--- a/lib/audrey/lib/rss/channel.ex
+++ b/lib/audrey/lib/rss/channel.ex
@@ -2,13 +2,14 @@ defmodule Audrey.RSS.Channel do
   import SweetXml
   import Audrey.Util, only: [format_value: 1]
 
-  defstruct [:title, :link, :description, items: []]
+  defstruct [:title, :link, :description, image: %{}, items: []]
 
   def parse(xml) do
     %Audrey.RSS.Channel{
       title: parse_title(xml),
       link: parse_link(xml),
       description: parse_description(xml),
+      image: parse_image(xml),
       items: parse_items(xml)
     }
   end
@@ -23,6 +24,10 @@ defmodule Audrey.RSS.Channel do
 
   defp parse_description(xml) do
     xml |> xpath(~x"./description/text()"s) |> format_value
+  end
+
+  defp parse_image(xml) do
+    xml |> xpath(~x"./image") |> Audrey.RSS.Image.parse
   end
 
   defp parse_items(xml) do

--- a/lib/audrey/lib/rss/image.ex
+++ b/lib/audrey/lib/rss/image.ex
@@ -1,0 +1,28 @@
+defmodule Audrey.RSS.Image do
+  import SweetXml
+  import Audrey.Util, only: [format_value: 1]
+
+  defstruct [:url, :title, :link]
+
+  def parse(nil), do: %Audrey.RSS.Image{}
+
+  def parse(xml) do
+    %Audrey.RSS.Image{
+      url: parse_url(xml),
+      title: parse_title(xml),
+      link: parse_link(xml)
+    }
+  end
+
+  defp parse_url(xml) do
+    xml |> xpath(~x"./url/text()"s) |> format_value
+  end
+
+  defp parse_title(xml) do
+    xml |> xpath(~x"./title/text()"s) |> format_value
+  end
+
+  defp parse_link(xml) do
+    xml |> xpath(~x"./link/text()"s) |> format_value
+  end
+end

--- a/test/audrey/audrey/rss/channel_test.exs
+++ b/test/audrey/audrey/rss/channel_test.exs
@@ -6,9 +6,14 @@ defmodule Audrey.RSS.ChannelTest do
   def channel_xml_basic do
     """
     <channel>
-      <title>JavaScript Fatigue</title>
-      <link>http://jsfatigue.com/</link>
-      <description>Too many tools. Too little time.</description>
+      <title>Ember Weekend</title>
+      <link>https://emberweekend.com/</link>
+      <description>Ember is a JavaScript framework</description>
+      <image>
+        <url>https://emberweekend.com/tomster.png</url>
+        <title>Ember Weekend</title>
+        <link>https://emberweekend.com</link>
+      </image>
       <item><title>Ember</title></item>
       <item><title>Angular</title></item>
       <item><title>React</title></item>
@@ -18,17 +23,26 @@ defmodule Audrey.RSS.ChannelTest do
 
   test "parses the title" do
     channel = channel_xml_basic |> parse
-    assert channel.title == "JavaScript Fatigue"
+    assert channel.title == "Ember Weekend"
   end
 
   test "parses the link" do
     channel = channel_xml_basic |> parse
-    assert channel.link == "http://jsfatigue.com/"
+    assert channel.link == "https://emberweekend.com/"
   end
 
   test "parses the description" do
     channel = channel_xml_basic |> parse
-    assert channel.description == "Too many tools. Too little time."
+    assert channel.description == "Ember is a JavaScript framework"
+  end
+
+  test "parses the image" do
+    channel = channel_xml_basic |> parse
+    assert channel.image == %Audrey.RSS.Image{
+      url: "https://emberweekend.com/tomster.png",
+      title: "Ember Weekend",
+      link: "https://emberweekend.com"
+    }
   end
 
   test "parses items" do

--- a/test/audrey/audrey/rss/image_test.exs
+++ b/test/audrey/audrey/rss/image_test.exs
@@ -1,0 +1,30 @@
+defmodule Audrey.RSS.ImageTest do
+  use ExUnit.Case, async: true
+
+  import Audrey.RSS.Image
+
+  def image_xml_basic do
+    """
+    <image>
+      <url>https://emberweekend.com/tomster.png</url>
+      <title>Ember Weekend</title>
+      <link>https://emberweekend.com</link>
+    </image>
+    """
+  end
+
+  test "parses the title" do
+    channel = image_xml_basic |> parse
+    assert channel.title == "Ember Weekend"
+  end
+
+  test "parses the url " do
+    channel = image_xml_basic |> parse
+    assert channel.url == "https://emberweekend.com/tomster.png"
+  end
+
+  test "parses the link" do
+    channel = image_xml_basic |> parse
+    assert channel.link == "https://emberweekend.com"
+  end
+end


### PR DESCRIPTION
Adds support for parsing the `<image>` sub-element of `<channel>` in RSS
feeds.