### PR TITLE
Remove unnecessary RSS namespace

### DIFF
--- a/lib/audrey/lib/channel.ex
+++ b/lib/audrey/lib/channel.ex
@@ -1,11 +1,11 @@
-defmodule Audrey.RSS.Channel do
+defmodule Audrey.Channel do
   import SweetXml
   import Audrey.Util, only: [format_value: 1]
 
-  defstruct [:title, :link, :description, image: %{}, items: []]
+  defstruct [:title, :link, :description, :image, items: []]
 
   def parse(xml) do
-    %Audrey.RSS.Channel{
+    %Audrey.Channel{
       title: parse_title(xml),
       link: parse_link(xml),
       description: parse_description(xml),
@@ -27,10 +27,10 @@ defmodule Audrey.RSS.Channel do
   end
 
   defp parse_image(xml) do
-    xml |> xpath(~x"./image") |> Audrey.RSS.Image.parse
+    xml |> xpath(~x"./image") |> Audrey.Image.parse
   end
 
   defp parse_items(xml) do
-    xml |> xpath(~x"./item"l) |> Enum.map(&Audrey.RSS.Item.parse(&1))
+    xml |> xpath(~x"./item"l) |> Enum.map(&Audrey.Item.parse(&1))
   end
 end

--- a/lib/audrey/lib/feed.ex
+++ b/lib/audrey/lib/feed.ex
@@ -8,6 +8,6 @@ defmodule Audrey.Feed do
   end
 
   defp parse_channel(xml) do
-    xml |> xpath(~x"//channel") |> Audrey.RSS.Channel.parse
+    xml |> xpath(~x"//channel") |> Audrey.Channel.parse
   end
 end

--- a/lib/audrey/lib/image.ex
+++ b/lib/audrey/lib/image.ex
@@ -1,13 +1,13 @@
-defmodule Audrey.RSS.Image do
+defmodule Audrey.Image do
   import SweetXml
   import Audrey.Util, only: [format_value: 1]
 
   defstruct [:url, :title, :link]
 
-  def parse(nil), do: %Audrey.RSS.Image{}
+  def parse(nil), do: nil
 
   def parse(xml) do
-    %Audrey.RSS.Image{
+    %Audrey.Image{
       url: parse_url(xml),
       title: parse_title(xml),
       link: parse_link(xml)

--- a/lib/audrey/lib/item.ex
+++ b/lib/audrey/lib/item.ex
@@ -1,11 +1,11 @@
-defmodule Audrey.RSS.Item do
+defmodule Audrey.Item do
   import SweetXml
   import Audrey.Util, only: [format_value: 1]
 
   defstruct [:title, :link, :description, :pub_date]
 
   def parse(xml) do
-    %Audrey.RSS.Item{
+    %Audrey.Item{
       title: parse_title(xml),
       link: parse_link(xml),
       description: parse_description(xml),

--- a/test/audrey/audrey/channel_test.exs
+++ b/test/audrey/audrey/channel_test.exs
@@ -1,7 +1,7 @@
-defmodule Audrey.RSS.ChannelTest do
+defmodule Audrey.ChannelTest do
   use ExUnit.Case, async: true
 
-  import Audrey.RSS.Channel
+  import Audrey.Channel
 
   def channel_xml_basic do
     """
@@ -21,24 +21,24 @@ defmodule Audrey.RSS.ChannelTest do
     """
   end
 
-  test "parses the title" do
+  test "parse/1: parses the title" do
     channel = channel_xml_basic |> parse
     assert channel.title == "Ember Weekend"
   end
 
-  test "parses the link" do
+  test "parse/1: parses the link" do
     channel = channel_xml_basic |> parse
     assert channel.link == "https://emberweekend.com/"
   end
 
-  test "parses the description" do
+  test "parse/1: parses the description" do
     channel = channel_xml_basic |> parse
     assert channel.description == "Ember is a JavaScript framework"
   end
 
-  test "parses the image" do
+  test "parse/1: parses the image" do
     channel = channel_xml_basic |> parse
-    assert channel.image == %Audrey.RSS.Image{
+    assert channel.image == %Audrey.Image{
       url: "https://emberweekend.com/tomster.png",
       title: "Ember Weekend",
       link: "https://emberweekend.com"

--- a/test/audrey/audrey/image_test.exs
+++ b/test/audrey/audrey/image_test.exs
@@ -1,7 +1,7 @@
-defmodule Audrey.RSS.ImageTest do
+defmodule Audrey.ImageTest do
   use ExUnit.Case, async: true
 
-  import Audrey.RSS.Image
+  import Audrey.Image
 
   def image_xml_basic do
     """

--- a/test/audrey/audrey/item_test.exs
+++ b/test/audrey/audrey/item_test.exs
@@ -1,7 +1,7 @@
-defmodule Audrey.RSS.ItemTest do
+defmodule Audrey.ItemTest do
   use ExUnit.Case, async: true
 
-  import Audrey.RSS.Item
+  import Audrey.Item
 
   def item_xml_basic do
     """


### PR DESCRIPTION
I don't have plans to support anything other than RSS right now and this namespace seems premature. I'd rather keep things simple for now and add this if it's ever needed.