### PR TITLE
Attach parsed items to feeds rather than channels

### DIFF
--- a/lib/audrey/lib/channel.ex
+++ b/lib/audrey/lib/channel.ex
@@ -2,15 +2,14 @@ defmodule Audrey.Channel do
   import SweetXml
   import Audrey.Util, only: [format_value: 1]
 
-  defstruct [:title, :link, :description, :image, items: []]
+  defstruct [:title, :link, :description, :image]
 
   def parse(xml) do
     %Audrey.Channel{
       title: parse_title(xml),
       link: parse_link(xml),
       description: parse_description(xml),
-      image: parse_image(xml),
-      items: parse_items(xml)
+      image: parse_image(xml)
     }
   end
 
@@ -28,9 +27,5 @@ defmodule Audrey.Channel do
 
   defp parse_image(xml) do
     xml |> xpath(~x"./image") |> Audrey.Image.parse
-  end
-
-  defp parse_items(xml) do
-    xml |> xpath(~x"./item"l) |> Enum.map(&Audrey.Item.parse(&1))
   end
 end

--- a/lib/audrey/lib/feed.ex
+++ b/lib/audrey/lib/feed.ex
@@ -1,13 +1,20 @@
 defmodule Audrey.Feed do
-  import SweetXml
+  import SweetXml, except: [parse: 1]
 
-  defstruct [:channel]
+  defstruct [:channel, items: []]
 
   def parse(xml) do
-    %Audrey.Feed{channel: parse_channel(xml)}
+    %Audrey.Feed{
+      channel: parse_channel(xml),
+      items: parse_items(xml)
+    }
   end
 
   defp parse_channel(xml) do
     xml |> xpath(~x"//channel") |> Audrey.Channel.parse
+  end
+
+  defp parse_items(xml) do
+    xml |> xpath(~x"//item"l) |> Enum.map(&Audrey.Item.parse(&1))
   end
 end

--- a/test/audrey/audrey/channel_test.exs
+++ b/test/audrey/audrey/channel_test.exs
@@ -44,11 +44,4 @@ defmodule Audrey.ChannelTest do
       link: "https://emberweekend.com"
     }
   end
-
-  test "parses items" do
-    channel = channel_xml_basic |> parse
-    item_titles = Enum.map(channel.items, &Map.get(&1, :title))
-
-    assert item_titles == ["Ember", "Angular", "React"]
-  end
 end

--- a/test/audrey/audrey/feed_test.exs
+++ b/test/audrey/audrey/feed_test.exs
@@ -1,0 +1,32 @@
+defmodule Audrey.RSS.FeedTest do
+  use ExUnit.Case, async: true
+
+  import Audrey.Feed
+
+  def feed_xml_basic do
+    """
+    <rss>
+      <channel>
+        <title>Ember Weekend</title>
+        <item><title>Ember</title></item>
+        <item><title>Angular</title></item>
+        <item><title>React</title></item>
+      </channel>
+    </rss>
+    """
+  end
+
+  test "parse/1: parses the channel" do
+    result = feed_xml_basic() |> parse()
+    assert result.channel == %Audrey.Channel{title: "Ember Weekend"}
+  end
+
+  test "parse/1: parses the items" do
+    result = feed_xml_basic() |> parse()
+    assert result.items == [
+      %Audrey.Item{title: "Ember"},
+      %Audrey.Item{title: "Angular"},
+      %Audrey.Item{title: "React"}
+    ]
+  end
+end


### PR DESCRIPTION
This moves the items list to as a property of the `Audrey.Feed` rather than the `Audrey.Channel` to make the feed easier to work with.