### PR TITLE
Cleanup pagination

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,5 +28,7 @@ config :phoenix, :generators,
   migration: true,
   binary_id: true
 
+config :phoenix, :format_encoders, "json-api": Poison
+
 # Configure plug to handle JSON API mime type
 config :plug, :mimes, %{"application/vnd.api+json" => ["json-api"]}

--- a/test/controllers/episode_controller_test.exs
+++ b/test/controllers/episode_controller_test.exs
@@ -72,6 +72,23 @@ defmodule Opencast.EpisodeControllerTest do
     ]
   end
 
+  test "index: is paginated", %{conn: conn} do
+    podcast = create(:podcast)
+    create_list(5, :episode, podcast: podcast)
+
+    conn = get conn, episode_path(conn, :index, page: %{"page" => 2, "page-size" => 1})
+    response = json_response(conn, 200)
+
+    assert length(response["data"]) == 1
+    assert response["links"] == %{
+      "self" => episode_path(conn, :index, page: %{"page" => 2, "page-size" => 1}),
+      "prev" => episode_path(conn, :index, page: %{"page" => 1, "page-size" => 1}),
+      "next" => episode_path(conn, :index, page: %{"page" => 3, "page-size" => 1}),
+      "last" => episode_path(conn, :index, page: %{"page" => 5, "page-size" => 1}),
+      "first" => episode_path(conn, :index, page: %{"page" => 1, "page-size" => 1})
+    }
+  end
+
   test "shows chosen resource", %{conn: conn} do
     episode = create(:episode)
 

--- a/test/controllers/podcast_controller_test.exs
+++ b/test/controllers/podcast_controller_test.exs
@@ -77,6 +77,22 @@ defmodule Opencast.PodcastControllerTest do
     ]
   end
 
+  test "index: is paginated", %{conn: conn} do
+    create_list(5, :podcast)
+
+    conn = get conn, podcast_path(conn, :index, page: %{"page" => 2, "page-size" => 1})
+    response = json_response(conn, 200)
+
+    assert length(response["data"]) == 1
+    assert response["links"] == %{
+      "self" => podcast_path(conn, :index, page: %{"page" => 2, "page-size" => 1}),
+      "prev" => podcast_path(conn, :index, page: %{"page" => 1, "page-size" => 1}),
+      "next" => podcast_path(conn, :index, page: %{"page" => 3, "page-size" => 1}),
+      "last" => podcast_path(conn, :index, page: %{"page" => 5, "page-size" => 1}),
+      "first" => podcast_path(conn, :index, page: %{"page" => 1, "page-size" => 1})
+    }
+  end
+
   test "shows chosen resource", %{conn: conn} do
     podcast = create(:podcast)
 

--- a/web/controllers/episode_controller.ex
+++ b/web/controllers/episode_controller.ex
@@ -7,11 +7,11 @@ defmodule Opencast.EpisodeController do
   alias Opencast.PodcastView
 
   def index(conn, params) do
-    page =
+    episodes =
       from(e in Episode, preload: [:podcast])
-      |> Repo.paginate(params)
+      |> Repo.paginate(Map.get(params, "page", %{}))
 
-    render(conn, "index.json", data: page.entries)
+    render(conn, "index.json", data: episodes)
   end
 
   def show(conn, %{"id" => id}) do

--- a/web/controllers/podcast_controller.ex
+++ b/web/controllers/podcast_controller.ex
@@ -8,11 +8,11 @@ defmodule Opencast.PodcastController do
   alias Opencast.Podcast
 
   def index(conn, params) do
-    page =
+    podcasts =
       from(p in Podcast, preload: [:episodes])
-      |> Repo.paginate(params)
+      |> Repo.paginate(Map.get(params, "page", %{}))
 
-    render(conn, "index.json", data: page.entries)
+    render(conn, "index.json", data: podcasts)
   end
 
   def show(conn, %{"id" => id}) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -3,6 +3,8 @@ defmodule Opencast.Router do
 
   pipeline :api do
     plug :accepts, ["json-api"]
+    plug JaSerializer.ContentTypeNegotiation
+    plug JaSerializer.Deserializer
   end
 
   scope "/api/v1", Opencast do

--- a/web/views/podcast_view.ex
+++ b/web/views/podcast_view.ex
@@ -26,6 +26,5 @@ defmodule Opencast.PodcastView do
 
   def related_episodes_link(podcast, conn) do
     podcast_related_episodes_url(conn, :related_episodes, podcast.id)
-    # self: episode_related_podcast_url(conn, :related_podcast, episode.id)
   end
 end


### PR DESCRIPTION
This adjusts the pagination to actually include the pagination URLs in
the response.

Additionally, this enables the `JaSerializer.ContentTypeNegotiation` to
enforce the JSON API mime-type.